### PR TITLE
fix: (maybe) typo

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -40,7 +40,7 @@ function computeRa(ds: number, achievement: number): number {
     } else if (achievement < Achievement.Sp) {
         baseRa = 20.0
     } else if (achievement < Achievement.SS) {
-        baseRa = 20.0
+        baseRa = 20.3
     } else if (achievement < Achievement.SSp) {
         baseRa = 20.8
     } else if (achievement < Achievement.SSS) {


### PR DESCRIPTION
According to https://github.com/Yuri-YuzuChaN/maimaiDX/blob/main/libraries/maimai_best_50.py#L283 , baseRa for rating SS should be 20.3. Compute result with value 20.3 is right.